### PR TITLE
fix: 송금을 입금으로 워딩 통일

### DIFF
--- a/src/pages/Discord/Discord.tsx
+++ b/src/pages/Discord/Discord.tsx
@@ -85,7 +85,7 @@ function Discord({ onNext, onPrev }: DiscordProps) {
             <Button
               className="border-2 border-gray-600"
               variant="secondary"
-              onClick={() => window.open("https://discord.com", "_blank")}
+              onClick={() => window.open(`${import.meta.env.VITE_DISCORD_INVITE_URL}`)}
             >
               디스코드
               <ExternalLink className="ml-2 h-4 w-4" />

--- a/src/pages/Payment/Payment.tsx
+++ b/src/pages/Payment/Payment.tsx
@@ -72,7 +72,7 @@ function Payment({
   return (
     <div className="space-y-4">
       <h3 className="font-semibold text-lg">회비 납부</h3>
-      <Label className="text-base">송금 안내</Label>
+      <Label className="text-base">입금 안내</Label>
       <Alert>
         <AlertDescription className="space-y-2 text-sm sm:text-base">
           <div className="flex items-center">
@@ -88,7 +88,7 @@ function Payment({
             </Button>
           </div>
           <div className="flex items-center">
-            <span className="w-20 font-medium">송금자명:</span>
+            <span className="w-20 font-medium">입금자명:</span>
             <span className="mr-1 pr-0">{senderName}</span>
             <Button
               variant="ghost"
@@ -100,7 +100,7 @@ function Payment({
             </Button>
           </div>
           <div className="flex items-center">
-            <span className="w-20 font-medium">송금할 금액:</span>
+            <span className="w-20 font-medium">입금할 금액:</span>
             <span>
               {isLoading
                 ? "로딩 중..."


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **스타일**  
  - 결제 관련 안내 문구와 레이블의 용어를 "송금"에서 "입금"으로 변경하여, 이용자들이 결제 정보를 보다 명확하게 인식할 수 있도록 개선하였습니다.
- **새로운 기능**  
  - Discord 버튼 클릭 시 열리는 URL을 하드코딩된 링크에서 환경 변수로 변경하여, 보다 유연한 URL 관리가 가능해졌습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->