### PR TITLE
feat(JOIN-66): 이전이랑 다음버튼 기능 추가 및 스타일 수정

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -5,7 +5,7 @@ import Payment from "@/pages/Payment/Payment";
 import PersonalInfo from "@/pages/PersonalInfo/PersonalInfo";
 import Survey from "@/pages/Survey/Survey";
 import Title from "./components/ui/custom/title";
-import { JOIN_STEPS } from "./constants/joinSteps";
+
 import useFunnel from "./hooks/useFunnel";
 import Agreement from "./pages/Agreement/Agreement";
 import Coupon from "./pages/Coupon/Coupon";
@@ -13,9 +13,7 @@ import Discord from "./pages/Discord/Discord";
 import JoinComplete from "./pages/JoinComplete/JoinComplete";
 
 const App = () => {
-  const { currentStep, progress, next, prev } = useFunnel({
-    steps: JOIN_STEPS,
-  });
+  const { currentStep, progress, next, prev } = useFunnel();
 
   return (
     <div className="mx-auto mb-8 w-full max-w-md px-4 py-8 pb-28">

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -28,26 +28,11 @@ const App = () => {
 
       <Routes>
         <Route path="/agreement" element={<Agreement />} />
-        <Route
-          path="/personal-info"
-          element={<PersonalInfo />}
-        />
-        <Route
-          path="/survey"
-          element={<Survey />}
-        />
-        <Route
-          path="/discord"
-          element={<Discord />}
-        />
-        <Route
-          path="/coupon"
-          element={<Coupon />}
-        />
-        <Route
-          path="/payment"
-          element={<Payment />}
-        />
+        <Route path="/personal-info" element={<PersonalInfo />} />
+        <Route path="/survey" element={<Survey />} />
+        <Route path="/discord" element={<Discord />} />
+        <Route path="/coupon" element={<Coupon />} />
+        <Route path="/payment" element={<Payment />} />
         <Route path="/complete" element={<JoinComplete />} />
 
         <Route path="*" element={<Navigate to={`/${currentStep}`} replace />} />

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -23,30 +23,30 @@ const App = () => {
         pauseOnFocusLoss={false}
       />
 
-      <Title currentStep={currentStep} onPrev={prev} />
+      <Title currentStep={currentStep} />
       <Progress value={progress} className="mt-4 mb-8 h-0.5 w-full" />
 
       <Routes>
         <Route path="/agreement" element={<Agreement />} />
         <Route
           path="/personal-info"
-          element={<PersonalInfo onNext={next} onPrev={prev} />}
+          element={<PersonalInfo />}
         />
         <Route
           path="/survey"
-          element={<Survey onNext={next} onPrev={prev} />}
+          element={<Survey />}
         />
         <Route
           path="/discord"
-          element={<Discord onNext={next} onPrev={prev} />}
+          element={<Discord />}
         />
         <Route
           path="/coupon"
-          element={<Coupon onNext={next} onPrev={prev} />}
+          element={<Coupon />}
         />
         <Route
           path="/payment"
-          element={<Payment onNext={next} onPrev={prev} />}
+          element={<Payment />}
         />
         <Route path="/complete" element={<JoinComplete />} />
 

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -16,7 +16,7 @@ const App = () => {
   const { currentStep, progress } = useFunnel();
 
   return (
-    <div className="mx-auto mb-8 w-full max-w-md px-4 py-8 pb-28">
+    <div className="mx-auto mb-8 w-full max-w-md px-4 py-8 pb-28 ">
       <ToastContainer
         position="top-center"
         draggable={true}

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -13,7 +13,7 @@ import Discord from "./pages/Discord/Discord";
 import JoinComplete from "./pages/JoinComplete/JoinComplete";
 
 const App = () => {
-  const { currentStep, progress, next, prev } = useFunnel();
+  const { currentStep, progress } = useFunnel();
 
   return (
     <div className="mx-auto mb-8 w-full max-w-md px-4 py-8 pb-28">

--- a/src/components/ui/custom/navigationButton.tsx
+++ b/src/components/ui/custom/navigationButton.tsx
@@ -1,13 +1,17 @@
-import { useLayoutEffect, useState } from "react";
+import { useCallback, useLayoutEffect, useState } from "react";
 import { Button } from "@/components/ui/button";
 import useFunnel from "@/hooks/useFunnel";
 
 interface NavigationButtonsProps {
   isValid?: boolean;
+  onFetch?: () => Promise<boolean>;
+  text?: string;
 }
 
-export default function NavigationButtons({ isValid }: NavigationButtonsProps) {
+export default function NavigationButtons({ isValid, onFetch, text }: NavigationButtonsProps) {
   const { next } = useFunnel();
+
+  const [isLoading, setIsLoading] = useState<boolean>(true);
   const [buttonVariant, setButtonVariant] = useState<"default" | "secondary">(
     "default"
   );
@@ -15,12 +19,41 @@ export default function NavigationButtons({ isValid }: NavigationButtonsProps) {
   useLayoutEffect(() => {
     setButtonVariant(isValid ? "default" : "secondary");
   }, [isValid]);
+  
+  const handleNext = useCallback(async () => {
+    if (isLoading || !isValid) return;
+
+    if(!onFetch) {
+      next();
+      return;
+    }
+
+    setIsLoading(true);
+    try {
+      const isSuccess = await onFetch();
+      if(isSuccess) {
+        next();
+      } else {
+        console.error("Error on fetch");
+      }
+    } catch (error) {
+      console.error("Error on fetch");
+    } finally {
+      setIsLoading(false);
+    }
+  }, [isLoading, isValid, onFetch, next]);
 
   return (
     <div className="fixed right-0 bottom-0 left-0 flex justify-center bg-background/80 p-4 backdrop-blur-xs">
       <div className="mx-auto flex w-full max-w-md justify-between py-2">
-        <Button onClick={next} variant={buttonVariant} size="lg" className="min-w-full">
-          다음
+        <Button
+          onClick={handleNext}
+          variant={buttonVariant}
+          size="lg"
+          className="min-w-full"
+          disabled={isLoading || !isValid}
+        >
+          {text ? text : "다음"}
         </Button>
       </div>
     </div>

--- a/src/components/ui/custom/navigationButton.tsx
+++ b/src/components/ui/custom/navigationButton.tsx
@@ -19,7 +19,7 @@ export default function NavigationButtons({ isValid }: NavigationButtonsProps) {
   return (
     <div className="fixed right-0 bottom-0 left-0 flex justify-center bg-background/80 p-4 backdrop-blur-xs">
       <div className="mx-auto flex w-full max-w-md justify-between py-2">
-        <Button onClick={next} variant={buttonVariant} size="lg">
+        <Button onClick={next} variant={buttonVariant} size="lg" className="min-w-full">
           다음
         </Button>
       </div>

--- a/src/components/ui/custom/navigationButton.tsx
+++ b/src/components/ui/custom/navigationButton.tsx
@@ -1,25 +1,15 @@
 import { useLayoutEffect, useState } from "react";
 import { Button } from "@/components/ui/button";
+import useFunnel from "@/hooks/useFunnel";
 
 interface NavigationButtonsProps {
-  prev: () => void;
-  next: () => void;
   isValid?: boolean;
-  showPrev?: boolean;
-  showNext?: boolean;
-}
-
-function navigationButtonStyle(visible: boolean) {
-  return `w-[42.5%] ${visible ? "invisible" : ""}`;
 }
 
 export default function NavigationButtons({
-  prev,
-  next,
   isValid,
-  showPrev = false,
-  showNext = false,
 }: NavigationButtonsProps) {
+  const { next } = useFunnel();
   const [buttonVariant, setButtonVariant] = useState<"default" | "secondary">(
     "default"
   );
@@ -32,19 +22,9 @@ export default function NavigationButtons({
     <div className="fixed right-0 bottom-0 left-0 flex justify-center bg-background/80 p-4 backdrop-blur-xs">
       <div className="mx-auto flex w-full max-w-md justify-between py-2">
         <Button
-          type="button"
-          variant="outline"
-          onClick={prev}
-          size="lg"
-          className={navigationButtonStyle(showPrev)}
-        >
-          이전
-        </Button>
-        <Button
           onClick={next}
           variant={buttonVariant}
           size="lg"
-          className={navigationButtonStyle(showNext)}
         >
           다음
         </Button>

--- a/src/components/ui/custom/navigationButton.tsx
+++ b/src/components/ui/custom/navigationButton.tsx
@@ -8,7 +8,11 @@ interface NavigationButtonsProps {
   text?: string;
 }
 
-export default function NavigationButtons({ isValid, onFetch, text }: NavigationButtonsProps) {
+export default function NavigationButtons({
+  isValid,
+  onFetch,
+  text,
+}: NavigationButtonsProps) {
   const { next } = useFunnel();
 
   const [isLoading, setIsLoading] = useState<boolean>(true);
@@ -19,11 +23,11 @@ export default function NavigationButtons({ isValid, onFetch, text }: Navigation
   useLayoutEffect(() => {
     setButtonVariant(isValid ? "default" : "secondary");
   }, [isValid]);
-  
+
   const handleNext = useCallback(async () => {
     if (isLoading || !isValid) return;
 
-    if(!onFetch) {
+    if (!onFetch) {
       next();
       return;
     }
@@ -31,13 +35,13 @@ export default function NavigationButtons({ isValid, onFetch, text }: Navigation
     setIsLoading(true);
     try {
       const isSuccess = await onFetch();
-      if(isSuccess) {
+      if (isSuccess) {
         next();
       } else {
         console.error("Error on fetch");
       }
     } catch (error) {
-      console.error("Error on fetch");
+      console.error(`Error on fetch ${error}`);
     } finally {
       setIsLoading(false);
     }

--- a/src/components/ui/custom/navigationButton.tsx
+++ b/src/components/ui/custom/navigationButton.tsx
@@ -6,9 +6,7 @@ interface NavigationButtonsProps {
   isValid?: boolean;
 }
 
-export default function NavigationButtons({
-  isValid,
-}: NavigationButtonsProps) {
+export default function NavigationButtons({ isValid }: NavigationButtonsProps) {
   const { next } = useFunnel();
   const [buttonVariant, setButtonVariant] = useState<"default" | "secondary">(
     "default"
@@ -21,11 +19,7 @@ export default function NavigationButtons({
   return (
     <div className="fixed right-0 bottom-0 left-0 flex justify-center bg-background/80 p-4 backdrop-blur-xs">
       <div className="mx-auto flex w-full max-w-md justify-between py-2">
-        <Button
-          onClick={next}
-          variant={buttonVariant}
-          size="lg"
-        >
+        <Button onClick={next} variant={buttonVariant} size="lg">
           다음
         </Button>
       </div>

--- a/src/components/ui/custom/title.tsx
+++ b/src/components/ui/custom/title.tsx
@@ -1,14 +1,15 @@
 import { ArrowLeftIcon } from "lucide-react";
 import { Stack } from "@/components/layout/Stack";
 import { JOIN_STEP_KOREAN_MAP } from "@/constants/joinSteps";
+import useFunnel from "@/hooks/useFunnel";
 import { Button } from "../button";
 
 interface TitleProps {
   currentStep: string;
-  onPrev?: () => void;
 }
 
-const Title = ({ currentStep, onPrev }: TitleProps) => {
+const Title = ({ currentStep }: TitleProps) => {
+  const { prev } = useFunnel();
   const stepKeys = Object.keys(JOIN_STEP_KOREAN_MAP);
   const isFirstStep = currentStep === stepKeys[0];
   const isLastStep = currentStep === stepKeys[stepKeys.length - 1];
@@ -24,7 +25,7 @@ const Title = ({ currentStep, onPrev }: TitleProps) => {
   } else {
     return (
       <Stack>
-        <Button variant="icon" aria-label="Go back" onClick={onPrev}>
+        <Button variant="icon" aria-label="Go back" onClick={prev}>
           <ArrowLeftIcon size={28} />
         </Button>
         <h1 className="font-bold text-2xl">

--- a/src/hooks/useFunnel.tsx
+++ b/src/hooks/useFunnel.tsx
@@ -5,7 +5,6 @@ import { JOIN_STEPS } from "@/constants/joinSteps";
 const steps = JOIN_STEPS;
 
 const useFunnel = () => {
-  
   const navigate = useNavigate();
   const location = useLocation();
 
@@ -16,10 +15,10 @@ const useFunnel = () => {
     if (currentIndex === -1) {
       navigate(`/${steps[0]}`, { replace: true });
     }
-  }, [currentIndex, navigate, steps]);
+  }, [currentIndex, navigate]);
 
   const progress =
-    currentIndex > -1 ? ((currentIndex) / (steps.length-1)) * 100 : 0;
+    currentIndex > -1 ? (currentIndex / (steps.length - 1)) * 100 : 0;
 
   const next = () => {
     const nextStepIndex = currentIndex + 1;

--- a/src/hooks/useFunnel.tsx
+++ b/src/hooks/useFunnel.tsx
@@ -19,7 +19,7 @@ const useFunnel = () => {
   }, [currentIndex, navigate, steps]);
 
   const progress =
-    currentIndex > -1 ? ((currentIndex + 1) / steps.length) * 100 : 0;
+    currentIndex > -1 ? ((currentIndex) / (steps.length-1)) * 100 : 0;
 
   const next = () => {
     const nextStepIndex = currentIndex + 1;

--- a/src/hooks/useFunnel.tsx
+++ b/src/hooks/useFunnel.tsx
@@ -1,11 +1,11 @@
 import { useEffect } from "react";
 import { useLocation, useNavigate } from "react-router-dom";
+import { JOIN_STEPS } from "@/constants/joinSteps";
 
-export interface useFunnelProps {
-  steps: readonly string[];
-}
+const steps = JOIN_STEPS;
 
-const useFunnel = ({ steps }: useFunnelProps) => {
+const useFunnel = () => {
+  
   const navigate = useNavigate();
   const location = useLocation();
 

--- a/src/index.css
+++ b/src/index.css
@@ -133,13 +133,10 @@
 }
 
 @layer utilities {
-
   .table-row {
     height: 40px;
     display: table-row;
   }
-
-
 
   .line-breaks {
     word-break: keep-all;

--- a/src/index.css
+++ b/src/index.css
@@ -133,18 +133,13 @@
 }
 
 @layer utilities {
-  body {
-    overflow-y: scroll;
-  }
 
   .table-row {
     height: 40px;
     display: table-row;
   }
 
-  html {
-    overflow-y: scroll;
-  }
+
 
   .line-breaks {
     word-break: keep-all;

--- a/src/pages/Coupon/Coupon.tsx
+++ b/src/pages/Coupon/Coupon.tsx
@@ -2,7 +2,6 @@ import { CircleAlert } from "lucide-react";
 import { useEffect, useState } from "react";
 import AlertBox from "@/components/ui/custom/alertbox";
 import NavigationButtons from "@/components/ui/custom/navigationButton";
-import useFunnel from "@/hooks/useFunnel";
 import { fetchCoupon, submitCoupon } from "./Coupon.Api";
 import { CouponList } from "./Coupon.CouponList";
 import InputCouponCode from "./Coupon.InputCouponCode";
@@ -10,7 +9,6 @@ import { TotalAmount } from "./Coupon.TotalAmount";
 import type { Coupon as CouponType } from "./Coupon.Types";
 
 const Coupon = () => {
-  const { next } = useFunnel();
   const [coupons, setCoupons] = useState<CouponType[]>([]);
   const [selectedCoupons, setSelectedCoupons] = useState<number[]>([]);
 
@@ -27,12 +25,13 @@ const Coupon = () => {
     fetchData();
   }, []);
 
-  const _onSubmit = async () => {
+  const onSubmit = async (): Promise<boolean> => {
     try {
       await submitCoupon(selectedCoupons);
-      next();
+      return true;
     } catch (error: unknown) {
       console.error("제출 중 오류 발생:", error);
+      return false;
     }
   };
 
@@ -55,7 +54,7 @@ const Coupon = () => {
       </div>
       <TotalAmount coupons={coupons} selectedCoupons={selectedCoupons} />
       <InputCouponCode setCoupons={setCoupons} />
-      <NavigationButtons isValid={true} />
+      <NavigationButtons isValid={true} onFetch={onSubmit} />
     </div>
   );
 };

--- a/src/pages/Coupon/Coupon.tsx
+++ b/src/pages/Coupon/Coupon.tsx
@@ -27,7 +27,7 @@ const Coupon = () => {
     fetchData();
   }, []);
 
-  const onSubmit = async () => {
+  const _onSubmit = async () => {
     try {
       await submitCoupon(selectedCoupons);
       next();

--- a/src/pages/Coupon/Coupon.tsx
+++ b/src/pages/Coupon/Coupon.tsx
@@ -2,19 +2,15 @@ import { CircleAlert } from "lucide-react";
 import { useEffect, useState } from "react";
 import AlertBox from "@/components/ui/custom/alertbox";
 import NavigationButtons from "@/components/ui/custom/navigationButton";
+import useFunnel from "@/hooks/useFunnel";
 import { fetchCoupon, submitCoupon } from "./Coupon.Api";
 import { CouponList } from "./Coupon.CouponList";
 import InputCouponCode from "./Coupon.InputCouponCode";
 import { TotalAmount } from "./Coupon.TotalAmount";
 import type { Coupon as CouponType } from "./Coupon.Types";
 
-const Coupon = ({
-  onNext,
-  onPrev,
-}: {
-  onNext: () => void;
-  onPrev: () => void;
-}) => {
+const Coupon = () => {
+  const { next } = useFunnel();
   const [coupons, setCoupons] = useState<CouponType[]>([]);
   const [selectedCoupons, setSelectedCoupons] = useState<number[]>([]);
 
@@ -34,7 +30,7 @@ const Coupon = ({
   const onSubmit = async () => {
     try {
       await submitCoupon(selectedCoupons);
-      onNext();
+      next();
     } catch (error: unknown) {
       console.error("제출 중 오류 발생:", error);
     }
@@ -59,7 +55,7 @@ const Coupon = ({
       </div>
       <TotalAmount coupons={coupons} selectedCoupons={selectedCoupons} />
       <InputCouponCode setCoupons={setCoupons} />
-      <NavigationButtons prev={onPrev} next={onSubmit} isValid={true} />
+      <NavigationButtons isValid={true} />
     </div>
   );
 };

--- a/src/pages/Discord/Discord.tsx
+++ b/src/pages/Discord/Discord.tsx
@@ -1,17 +1,14 @@
 import { useCallback, useEffect, useState } from "react";
 import DiscordLinkButton from "@/components/ui/custom/discord-link-button";
 import NavigationButtons from "@/components/ui/custom/navigationButton";
+import useFunnel from "@/hooks/useFunnel";
 import DiscordCode from "@/pages/Discord/Discord.Code";
 import { fetchDiscordCode, startDiscordPolling } from "./Discord.Api";
 import DiscordComplete from "./Discord.Complete";
 import { DiscordWhy } from "./Discord.Why";
 
-interface DiscordProps {
-  onNext: () => void;
-  onPrev: () => void;
-}
-
-const Discord = ({ onNext, onPrev }: DiscordProps) => {
+const Discord = () => {
+  const { next } = useFunnel();
   const [code, setCode] = useState<string>("");
   const [isValid, setIsValid] = useState<boolean>(false);
 
@@ -38,8 +35,8 @@ const Discord = ({ onNext, onPrev }: DiscordProps) => {
   }, [getDiscordCode]);
 
   const handleNext = useCallback(() => {
-    if (isValid) onNext();
-  }, [isValid, onNext]);
+    if (isValid) next();
+  }, [isValid, next]);
 
   return (
     <div className="gap-12 space-y-4 py-9">
@@ -60,7 +57,7 @@ const Discord = ({ onNext, onPrev }: DiscordProps) => {
           <DiscordWhy />
         </div>
       )}
-      <NavigationButtons prev={onPrev} next={handleNext} isValid={isValid} />
+      <NavigationButtons isValid={isValid} />
     </div>
   );
 };

--- a/src/pages/Discord/Discord.tsx
+++ b/src/pages/Discord/Discord.tsx
@@ -1,14 +1,12 @@
 import { useCallback, useEffect, useState } from "react";
 import DiscordLinkButton from "@/components/ui/custom/discord-link-button";
 import NavigationButtons from "@/components/ui/custom/navigationButton";
-import useFunnel from "@/hooks/useFunnel";
 import DiscordCode from "@/pages/Discord/Discord.Code";
 import { fetchDiscordCode, startDiscordPolling } from "./Discord.Api";
 import DiscordComplete from "./Discord.Complete";
 import { DiscordWhy } from "./Discord.Why";
 
 const Discord = () => {
-  const { next } = useFunnel();
   const [code, setCode] = useState<string>("");
   const [isValid, setIsValid] = useState<boolean>(false);
 
@@ -33,10 +31,6 @@ const Discord = () => {
       cleanupPolling();
     };
   }, [getDiscordCode]);
-
-  const _handleNext = useCallback(() => {
-    if (isValid) next();
-  }, [isValid, next]);
 
   return (
     <div className="gap-12 space-y-4 py-9">

--- a/src/pages/Discord/Discord.tsx
+++ b/src/pages/Discord/Discord.tsx
@@ -34,7 +34,7 @@ const Discord = () => {
     };
   }, [getDiscordCode]);
 
-  const handleNext = useCallback(() => {
+  const _handleNext = useCallback(() => {
     if (isValid) next();
   }, [isValid, next]);
 

--- a/src/pages/Payment/Payment.tsx
+++ b/src/pages/Payment/Payment.tsx
@@ -3,19 +3,15 @@ import { useCallback, useEffect, useState } from "react";
 import { Alert, AlertTitle } from "@/components/ui/alert";
 import AlertBox from "@/components/ui/custom/alertbox";
 import NavigationButtons from "@/components/ui/custom/navigationButton";
+import useFunnel from "@/hooks/useFunnel";
 import type { GetPaymentInfo } from "@/types/api/payment";
 import { startPaymentPolling } from "./Payment.Api";
 import { ADMIN_INFO } from "./Payment.Config";
 // import HowtoDo from "./Payment.HowtoDo";
 import Information from "./Payment.Information";
 
-const Payment = ({
-  onNext,
-  onPrev,
-}: {
-  onNext: () => void;
-  onPrev: () => void;
-}) => {
+const Payment = () => {
+  const { next } = useFunnel();
   const [isValid, setIsValid] = useState(false);
   const [remainingAmount, setRemainingAmount] = useState(0);
   const [payInfo, setPayInfo] = useState<GetPaymentInfo | null>(null);
@@ -42,8 +38,8 @@ const Payment = ({
 
   const handleNext = useCallback(() => {
     if (!isValid || payInfo?.status === "PENDING") return;
-    onNext();
-  }, [onNext, isValid, payInfo?.status]);
+    next();
+  }, [next, isValid, payInfo?.status]);
 
   return (
     <div className="line-breaks space-y-4">
@@ -88,12 +84,7 @@ const Payment = ({
       )}
 
       {/* <HowtoDo /> */}
-      <NavigationButtons
-        prev={onPrev}
-        next={handleNext}
-        isValid={isValid}
-        showPrev={isValid}
-      />
+      <NavigationButtons isValid={isValid} showPrev={isValid} />
     </div>
   );
 };

--- a/src/pages/Payment/Payment.tsx
+++ b/src/pages/Payment/Payment.tsx
@@ -36,7 +36,7 @@ const Payment = () => {
     }
   }, [payInfo]);
 
-  const handleNext = useCallback(() => {
+  const _handleNext = useCallback(() => {
     if (!isValid || payInfo?.status === "PENDING") return;
     next();
   }, [next, isValid, payInfo?.status]);

--- a/src/pages/Payment/Payment.tsx
+++ b/src/pages/Payment/Payment.tsx
@@ -1,9 +1,8 @@
 import { CircleAlert, CircleCheckBig, LoaderCircle } from "lucide-react";
-import { useCallback, useEffect, useState } from "react";
+import { useEffect, useState } from "react";
 import { Alert, AlertTitle } from "@/components/ui/alert";
 import AlertBox from "@/components/ui/custom/alertbox";
 import NavigationButtons from "@/components/ui/custom/navigationButton";
-import useFunnel from "@/hooks/useFunnel";
 import type { GetPaymentInfo } from "@/types/api/payment";
 import { startPaymentPolling } from "./Payment.Api";
 import { ADMIN_INFO } from "./Payment.Config";
@@ -11,7 +10,6 @@ import { ADMIN_INFO } from "./Payment.Config";
 import Information from "./Payment.Information";
 
 const Payment = () => {
-  const { next } = useFunnel();
   const [isValid, setIsValid] = useState(false);
   const [remainingAmount, setRemainingAmount] = useState(0);
   const [payInfo, setPayInfo] = useState<GetPaymentInfo | null>(null);
@@ -35,11 +33,6 @@ const Payment = () => {
       );
     }
   }, [payInfo]);
-
-  const _handleNext = useCallback(() => {
-    if (!isValid || payInfo?.status === "PENDING") return;
-    next();
-  }, [next, isValid, payInfo?.status]);
 
   return (
     <div className="line-breaks space-y-4">
@@ -83,8 +76,7 @@ const Payment = () => {
         </div>
       )}
 
-      {/* <HowtoDo /> */}
-      <NavigationButtons isValid={isValid} showPrev={isValid} />
+      <NavigationButtons isValid={isValid} />
     </div>
   );
 };

--- a/src/pages/PersonalInfo/PersonalInfo.tsx
+++ b/src/pages/PersonalInfo/PersonalInfo.tsx
@@ -73,9 +73,7 @@ const PersonalInfo = () => {
         <StudentDepartment name="department" />
         <StudentGrade name="grade" />
         <StudentResidentNumber />
-        <NavigationButtons
-          isValid={methods.formState.isValid}
-        />
+        <NavigationButtons isValid={methods.formState.isValid} />
       </form>
     </FormProvider>
   );

--- a/src/pages/PersonalInfo/PersonalInfo.tsx
+++ b/src/pages/PersonalInfo/PersonalInfo.tsx
@@ -2,6 +2,7 @@ import { zodResolver } from "@hookform/resolvers/zod";
 import { useEffect } from "react";
 import { FormProvider, useForm } from "react-hook-form";
 import NavigationButtons from "@/components/ui/custom/navigationButton";
+import useFunnel from "@/hooks/useFunnel";
 import { usePersonalInfoStore } from "@/stores/usePersonalInfoStore";
 import { StudentDepartment } from "./field/studentDepartment";
 import { StudentGrade } from "./field/studentGrade";
@@ -17,12 +18,8 @@ import {
   personalInfoSchema,
 } from "./PersonalInfo.schema";
 
-interface PersonalInfoProps {
-  onNext: (data: PersonalInfoFormValues) => void;
-  onPrev: () => void;
-}
-
-const PersonalInfo = ({ onNext, onPrev }: PersonalInfoProps) => {
+const PersonalInfo = () => {
+  const { next } = useFunnel();
   const { personalInfoData, setPersonalInfoData, isInitial, setNotInitial } =
     usePersonalInfoStore();
 
@@ -58,7 +55,7 @@ const PersonalInfo = ({ onNext, onPrev }: PersonalInfoProps) => {
     submitPersonalInfoData(data)
       .then(() => {
         setPersonalInfoData(data);
-        onNext(data);
+        next();
       })
       .catch((error) => {
         console.error("제출 중 오류가 발생했습니다:", error);
@@ -77,13 +74,7 @@ const PersonalInfo = ({ onNext, onPrev }: PersonalInfoProps) => {
         <StudentGrade name="grade" />
         <StudentResidentNumber />
         <NavigationButtons
-          prev={() => {
-            setPersonalInfoData(methods.getValues());
-            onPrev();
-          }}
-          next={methods.handleSubmit(onSubmit)}
           isValid={methods.formState.isValid}
-          showPrev={true}
         />
       </form>
     </FormProvider>

--- a/src/pages/Survey/Survey.tsx
+++ b/src/pages/Survey/Survey.tsx
@@ -78,9 +78,7 @@ const Survey = () => {
           <JoinReason />
         </Container>
 
-        <NavigationButtons
-          isValid={methods.formState.isValid}
-        />
+        <NavigationButtons isValid={methods.formState.isValid} />
       </form>
     </FormProvider>
   );

--- a/src/pages/Survey/Survey.tsx
+++ b/src/pages/Survey/Survey.tsx
@@ -2,19 +2,15 @@ import { zodResolver } from "@hookform/resolvers/zod";
 import { useEffect } from "react";
 import { FormProvider, useForm } from "react-hook-form";
 import NavigationButtons from "@/components/ui/custom/navigationButton";
+import useFunnel from "@/hooks/useFunnel";
 import { useSurveyStore } from "@/stores/useSurveyStore";
 import { AcquisitionType } from "./Survey.AcquisitionType";
 import { fetchSurveyData, submitSurveyData } from "./Survey.Api";
 import JoinReason from "./Survey.JoinReason";
 import { type SurveyFormValues, surveySchema } from "./Survey.schema";
 
-const Survey = ({
-  onNext,
-  onPrev,
-}: {
-  onNext: () => void;
-  onPrev: () => void;
-}) => {
+const Survey = () => {
+  const { next } = useFunnel();
   const {
     joinReason,
     acquisitionType,
@@ -61,7 +57,7 @@ const Survey = ({
     submitSurveyData(data)
       .then(() => {
         setFormValues(data);
-        onNext();
+        next();
       })
       .catch((error) => {
         console.error("제출 중 오류가 발생했습니다:", error);
@@ -83,8 +79,6 @@ const Survey = ({
         </Container>
 
         <NavigationButtons
-          prev={onPrev}
-          next={methods.handleSubmit(onSubmit)}
           isValid={methods.formState.isValid}
         />
       </form>


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * 여러 페이지 및 컴포넌트에서 이전/다음 단계 이동을 위한 콜백(props) 제거 및 내부 훅 기반 내비게이션으로 전환하여 인터페이스를 단순화했습니다.
  * 내비게이션 버튼 UI가 단일 "다음" 버튼으로 변경되고, 비동기 처리 및 유효성에 따라 동작하도록 개선되었습니다.
  * 진행률 계산 방식이 조정되어 첫 단계에서 0%, 마지막 단계에서 100%로 표시됩니다.

* **Style**
  * body 및 html의 세로 스크롤 관련 CSS가 제거되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->