### PR TITLE
feat(JOIN-142): 다음 버튼을 조건부 랜더링 적용

### DIFF
--- a/src/pages/Discord/Discord.tsx
+++ b/src/pages/Discord/Discord.tsx
@@ -36,9 +36,12 @@ const Discord = () => {
   return (
     <div className="gap-12 space-y-4 py-9">
       {isValid ? (
-        <Suspense>
-          <Complete message="연동을 완료했어요" />
-        </Suspense>
+        <>
+          <Suspense>
+            <Complete message="연동을 완료했어요" />
+          </Suspense>
+          <NavigationButtons isValid={isValid} />
+        </>
       ) : (
         <div className="space-y-4">
           <DiscordCode
@@ -54,7 +57,7 @@ const Discord = () => {
           <DiscordWhy />
         </div>
       )}
-      <NavigationButtons isValid={isValid} />
+      
     </div>
   );
 };

--- a/src/pages/Discord/Discord.tsx
+++ b/src/pages/Discord/Discord.tsx
@@ -57,7 +57,6 @@ const Discord = () => {
           <DiscordWhy />
         </div>
       )}
-      
     </div>
   );
 };

--- a/src/pages/Payment/Payment.tsx
+++ b/src/pages/Payment/Payment.tsx
@@ -87,8 +87,6 @@ const Payment = () => {
               쿠폰 적용하기
             </Button>
             <AdminInfoDrawer />
-
-            
           </>
         ) : (
           <Suspense>
@@ -96,7 +94,6 @@ const Payment = () => {
             <NavigationButtons isValid={isValid} />
           </Suspense>
         )}
-
       </div>
       <AnimatePresence>
         {currentView === "coupon" && (

--- a/src/pages/Payment/Payment.tsx
+++ b/src/pages/Payment/Payment.tsx
@@ -78,23 +78,25 @@ const Payment = () => {
             <Label className="text-xl">납부 금액</Label>
             <PaymentAmount amount={remainingAmount} />
             <Information />
+            <Button
+              size="lg"
+              className=" w-full items-center"
+              variant="default"
+              onClick={() => setCurrentView("coupon")}
+            >
+              쿠폰 적용하기
+            </Button>
+            <AdminInfoDrawer />
+
+            
           </>
         ) : (
           <Suspense>
             <Complete message="납부가 완료됐어요" />
+            <NavigationButtons isValid={isValid} />
           </Suspense>
         )}
-        <Button
-          size="lg"
-          className=" w-full items-center"
-          variant="default"
-          onClick={() => setCurrentView("coupon")}
-        >
-          쿠폰 적용하기
-        </Button>
-        <AdminInfoDrawer />
 
-        <NavigationButtons isValid={isValid} />
       </div>
       <AnimatePresence>
         {currentView === "coupon" && (


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **버그 수정**
  * Discord 및 결제 페이지에서 유효성 상태에 따라 버튼과 컴포넌트가 조건부로 표시되도록 개선되었습니다. 이제 결제가 완료되었거나 유효할 때만 내비게이션 버튼이 보이고, 결제가 미완료일 때만 쿠폰 적용 버튼과 관리자 정보가 표시됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->