### PR TITLE
feat(JOIN-156): 완료 페이지 레이아웃 수정

### DIFF
--- a/src/assets/kakao-logo.svg
+++ b/src/assets/kakao-logo.svg
@@ -1,19 +1,18 @@
 <svg
-  class=""
-  width="30"
-  height="30"
-  viewBox="0 0 48 48"
-  fill="none"
-  xmlns="http://www.w3.org/2000/svg"
-  role="img"
-  aria-labelledby="kakao-icon-title"
+ class=""
+ width="30"
+ height="30"
+ viewBox="0 0 48 48"
+ fill="none"
+ xmlns="http://www.w3.org/2000/svg"
+ role="img"
+ aria-labelledby="kakao-icon-title"
 >
-  <title id="kakao-icon-title">카카오톡 아이콘</title>
-  <rect width="48" height="48" fill="var(--kakao-bg, #FEE500)" />
-  <path
-    fill-rule="evenodd"
-    clip-rule="evenodd"
-    d="M24 12C16.268 12 10 16.9249 10 23C10 26.8381 12.508 30.2103 16.2381 32.1796L14.7605 37.5663C14.6852 37.8485 14.9975 38.0687 15.2445 37.9049L21.5973 33.8505C22.3805 33.9492 23.1801 34 24 34C31.732 34 38 29.0751 38 23C38 16.9249 31.732 12 24 12Z"
-    fill="var(--kakao-icon, #000000)"
-  />
+ <title id="kakao-icon-title">카카오톡 아이콘</title>
+ <path
+ fill-rule="evenodd"
+ clip-rule="evenodd"
+ d="M24 12C16.268 12 10 16.9249 10 23C10 26.8381 12.508 30.2103 16.2381 32.1796L14.7605 37.5663C14.6852 37.8485 14.9975 38.0687 15.2445 37.9049L21.5973 33.8505C22.3805 33.9492 23.1801 34 24 34C31.732 34 38 29.0751 38 23C38 16.9249 31.732 12 24 12Z"
+ fill="var(--kakao-icon, #000000)"
+ />
 </svg>

--- a/src/pages/JoinComplete/JoinComplete.DiscordNotice.tsx
+++ b/src/pages/JoinComplete/JoinComplete.DiscordNotice.tsx
@@ -3,8 +3,8 @@ import DiscordLinkButton from "@/components/ui/custom/discord-link-button";
 const DiscordNotice = () => {
   return (
     <div className="break-words pt-8">
-      <p className="line-breaks mb-1 text-center text-lg">
-        앞으로의 모든 활동과 소통은 <strong>디스코드</strong>에서 이루어집니다.
+      <p className="line-breaks mb-1 text-center text-muted-foreground">
+        주요 활동과 소통은 <strong>디스코드</strong>에서 이루어져요.
         Aegis와 함께 성장해 나가요!
       </p>
       <DiscordLinkButton

--- a/src/pages/JoinComplete/JoinComplete.DiscordNotice.tsx
+++ b/src/pages/JoinComplete/JoinComplete.DiscordNotice.tsx
@@ -4,8 +4,8 @@ const DiscordNotice = () => {
   return (
     <div className="break-words pt-8">
       <p className="line-breaks mb-1 text-center text-muted-foreground">
-        주요 활동과 소통은 <strong>디스코드</strong>에서 이루어져요.
-        Aegis와 함께 성장해 나가요!
+        주요 활동과 소통은 <strong>디스코드</strong>에서 이루어져요. Aegis와
+        함께 성장해 나가요!
       </p>
       <DiscordLinkButton
         text="디스코드 공지방"

--- a/src/pages/JoinComplete/JoinComplete.KakaoChatroom.tsx
+++ b/src/pages/JoinComplete/JoinComplete.KakaoChatroom.tsx
@@ -1,16 +1,31 @@
+import { Check, Copy } from "lucide-react";
 import { forwardRef, useState } from "react";
 import KakaoIcon from "@/assets/kakao-logo.svg";
 import { Button } from "@/components/ui/button";
-import { Dialog, DialogContent, DialogDescription, DialogHeader, DialogTitle, DialogTrigger } from "@/components/ui/dialog";
-import { Drawer, DrawerTrigger, DrawerContent, DrawerHeader, DrawerTitle, DrawerDescription, DrawerFooter, DrawerClose } from "@/components/ui/drawer";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+  DialogTrigger,
+} from "@/components/ui/dialog";
+import {
+  Drawer,
+  DrawerClose,
+  DrawerContent,
+  DrawerDescription,
+  DrawerFooter,
+  DrawerHeader,
+  DrawerTitle,
+  DrawerTrigger,
+} from "@/components/ui/drawer";
 import useMediaQuery from "@/hooks/useMediaQuery";
-import { Check, Copy, Info } from "lucide-react";
-import React from "react";
 
 const TriggerButton = forwardRef<HTMLDivElement>((props, ref) => (
   <div ref={ref} className="flex items-center justify-center gap-2" {...props}>
-    <img src={KakaoIcon} alt="Kakao Icon" className="w-8 h-8" />
-    <span className="text-base font-semibold">카카오톡에서도 공지 받기</span>
+    <img src={KakaoIcon} alt="Kakao Icon" className="h-8 w-8" />
+    <span className="font-semibold text-base">카카오톡에서도 공지 받기</span>
   </div>
 ));
 TriggerButton.displayName = "TriggerButton";
@@ -36,7 +51,10 @@ const Content = () => {
   return (
     <div className="flex flex-col gap-4 p-4">
       <div className="space-y-2">
-        <label htmlFor="password" className="text-sm font-medium text-slate-600">
+        <label
+          htmlFor="password"
+          className="font-medium text-slate-600 text-sm"
+        >
           채팅방 비밀번호
         </label>
         <div className="flex items-center gap-2">
@@ -45,7 +63,7 @@ const Content = () => {
             type="text"
             value={password}
             readOnly
-            className="flex-1 px-3 py-2 text-center bg-slate-100 border rounded-md text-lg font-mono"
+            className="flex-1 rounded-md border bg-slate-100 px-3 py-2 text-center font-mono text-lg"
           />
           <Button
             variant="icon"
@@ -53,9 +71,9 @@ const Content = () => {
             aria-label="비밀번호 복사"
           >
             {copied ? (
-              <Check className="w-5 h-5 text-green-500" />
+              <Check className="h-5 w-5 text-green-500" />
             ) : (
-              <Copy className="w-5 h-5" />
+              <Copy className="h-5 w-5" />
             )}
           </Button>
         </div>
@@ -64,7 +82,7 @@ const Content = () => {
       {/* 2. 참여하기 버튼 */}
       <Button
         size="lg"
-        className="w-full bg-[#FEE500] text-black font-bold transition-all hover:bg-[#F7D300] active:scale-95"
+        className="w-full bg-[#FEE500] font-bold text-black transition-all hover:bg-[#F7D300] active:scale-95"
         onClick={handleJoin}
       >
         입장하기
@@ -85,11 +103,15 @@ const KakaoChatroom = () => {
     return (
       <Dialog open={open} onOpenChange={setOpen}>
         <DialogTrigger asChild>
-          <Button size="lg" className="w-full bg-[#FEE500] text-black transition-all hover:bg-[#F7D300] active:scale-95" asChild>
+          <Button
+            size="lg"
+            className="w-full bg-[#FEE500] text-black transition-all hover:bg-[#F7D300] active:scale-95"
+            asChild
+          >
             <TriggerButton />
           </Button>
         </DialogTrigger>
-        <DialogContent className="sm:max-w-sm p-0">
+        <DialogContent className="p-0 sm:max-w-sm">
           <DialogHeader className="p-6 pb-4">
             <DialogTitle>{title}</DialogTitle>
             <DialogDescription>{description}</DialogDescription>
@@ -103,7 +125,11 @@ const KakaoChatroom = () => {
   return (
     <Drawer open={open} onOpenChange={setOpen}>
       <DrawerTrigger asChild>
-        <Button size="lg" className="w-full bg-[#FEE500] text-black transition-all hover:bg-[#F7D300] active:scale-95" asChild>
+        <Button
+          size="lg"
+          className="w-full bg-[#FEE500] text-black transition-all hover:bg-[#F7D300] active:scale-95"
+          asChild
+        >
           <TriggerButton />
         </Button>
       </DrawerTrigger>

--- a/src/pages/JoinComplete/JoinComplete.KakaoChatroom.tsx
+++ b/src/pages/JoinComplete/JoinComplete.KakaoChatroom.tsx
@@ -21,8 +21,8 @@ const KakaoChatroom = () => {
 
   return (
     <div className="break-words pt-4">
-      <p className="line-breaks mb-1 text-center text-gray-600 text-sm">
-        오픈채팅방에서도 공지를 확인할 수 있습니다
+      <p className="line-breaks mb-1 text-center text-muted-foreground">
+        오픈채팅방에서도 공지를 확인할 수 있어요
       </p>
       <Button
         size="lg"

--- a/src/pages/JoinComplete/JoinComplete.KakaoChatroom.tsx
+++ b/src/pages/JoinComplete/JoinComplete.KakaoChatroom.tsx
@@ -1,52 +1,125 @@
-import { useState } from "react";
+import { forwardRef, useState } from "react";
 import KakaoIcon from "@/assets/kakao-logo.svg";
 import { Button } from "@/components/ui/button";
+import { Dialog, DialogContent, DialogDescription, DialogHeader, DialogTitle, DialogTrigger } from "@/components/ui/dialog";
+import { Drawer, DrawerTrigger, DrawerContent, DrawerHeader, DrawerTitle, DrawerDescription, DrawerFooter, DrawerClose } from "@/components/ui/drawer";
+import useMediaQuery from "@/hooks/useMediaQuery";
+import { Check, Copy, Info } from "lucide-react";
+import React from "react";
 
-type OpenChatStep = "copyCode" | "copied" | "enterOpenChat";
+const TriggerButton = forwardRef<HTMLDivElement>((props, ref) => (
+  <div ref={ref} className="flex items-center justify-center gap-2" {...props}>
+    <img src={KakaoIcon} alt="Kakao Icon" className="w-8 h-8" />
+    <span className="text-base font-semibold">카카오톡에서도 공지 받기</span>
+  </div>
+));
+TriggerButton.displayName = "TriggerButton";
 
-const KakaoChatroom = () => {
-  const [openChatStep, setOpenChatStep] = useState<OpenChatStep>("copyCode");
-  const password = import.meta.env.VITE_KAKAO_CHATROOM_PASSWORD; // 예시 비밀번호
+const Content = () => {
+  const [copied, setCopied] = useState(false);
+
+  const password = import.meta.env.VITE_KAKAO_CHATROOM_PASSWORD;
   const chatroomUrl = import.meta.env.VITE_KAKAO_CHATROOM_URL;
 
-  const handleClick = (e: React.MouseEvent<HTMLAnchorElement>) => {
-    if (openChatStep === "copyCode") {
-      e.preventDefault();
-      navigator.clipboard.writeText(password);
-      setOpenChatStep("copied");
-      setTimeout(() => setOpenChatStep("enterOpenChat"), 1000);
-    }
-    // "enterOpenChat" 상태에서는 링크의 기본 동작이 진행됩니다.
+  const handleCopy = () => {
+    navigator.clipboard.writeText(password).then(() => {
+      setCopied(true);
+
+      setTimeout(() => setCopied(false), 2000); // 2초 후 아이콘 원래대로
+    });
+  };
+
+  const handleJoin = () => {
+    window.open(chatroomUrl, "_blank", "noopener,noreferrer");
   };
 
   return (
-    <div className="break-words pt-4">
-      <p className="line-breaks mb-1 text-center text-muted-foreground">
-        오픈채팅방에서도 공지를 확인할 수 있어요
-      </p>
+    <div className="flex flex-col gap-4 p-4">
+      <div className="space-y-2">
+        <label htmlFor="password" className="text-sm font-medium text-slate-600">
+          채팅방 비밀번호
+        </label>
+        <div className="flex items-center gap-2">
+          <input
+            id="password"
+            type="text"
+            value={password}
+            readOnly
+            className="flex-1 px-3 py-2 text-center bg-slate-100 border rounded-md text-lg font-mono"
+          />
+          <Button
+            variant="icon"
+            onClick={handleCopy}
+            aria-label="비밀번호 복사"
+          >
+            {copied ? (
+              <Check className="w-5 h-5 text-green-500" />
+            ) : (
+              <Copy className="w-5 h-5" />
+            )}
+          </Button>
+        </div>
+      </div>
+
+      {/* 2. 참여하기 버튼 */}
       <Button
         size="lg"
-        className="w-full bg-[#FEE500] text-black transition-transform duration-100 hover:bg-[#FEE500] hover:text-black active:scale-95"
-        asChild
+        className="w-full bg-[#FEE500] text-black font-bold transition-all hover:bg-[#F7D300] active:scale-95"
+        onClick={handleJoin}
       >
-        <a
-          href={chatroomUrl}
-          target="_blank"
-          rel="noopener noreferrer"
-          onClick={handleClick}
-          className="flex items-center justify-center gap-0"
-        >
-          <img src={KakaoIcon} alt="Kakao Icon" />
-          <span className="text-[16px]">
-            {openChatStep === "copyCode"
-              ? "비밀번호 복사 및 채팅방 참여하기"
-              : openChatStep === "copied"
-                ? "복사되었습니다!"
-                : "오픈채팅방 참여하기!!"}
-          </span>
-        </a>
+        입장하기
       </Button>
     </div>
+  );
+};
+
+const KakaoChatroom = () => {
+  const [open, setOpen] = useState(false);
+  const isDesktop = useMediaQuery("(min-width: 768px)");
+
+  const title = "카카오톡 공지방 참여 안내";
+  const description =
+    "아래에서 비밀번호를 복사한 후, '입장하기' 버튼을 눌러 참여해주세요.";
+
+  if (isDesktop) {
+    return (
+      <Dialog open={open} onOpenChange={setOpen}>
+        <DialogTrigger asChild>
+          <Button size="lg" className="w-full bg-[#FEE500] text-black transition-all hover:bg-[#F7D300] active:scale-95" asChild>
+            <TriggerButton />
+          </Button>
+        </DialogTrigger>
+        <DialogContent className="sm:max-w-sm p-0">
+          <DialogHeader className="p-6 pb-4">
+            <DialogTitle>{title}</DialogTitle>
+            <DialogDescription>{description}</DialogDescription>
+          </DialogHeader>
+          <Content />
+        </DialogContent>
+      </Dialog>
+    );
+  }
+
+  return (
+    <Drawer open={open} onOpenChange={setOpen}>
+      <DrawerTrigger asChild>
+        <Button size="lg" className="w-full bg-[#FEE500] text-black transition-all hover:bg-[#F7D300] active:scale-95" asChild>
+          <TriggerButton />
+        </Button>
+      </DrawerTrigger>
+      <DrawerContent>
+        <DrawerHeader className="text-left">
+          <DrawerTitle>{title}</DrawerTitle>
+          <DrawerDescription>{description}</DrawerDescription>
+        </DrawerHeader>
+        <Content />
+        <DrawerFooter className="pt-2">
+          <DrawerClose asChild>
+            <Button variant="outline">닫기</Button>
+          </DrawerClose>
+        </DrawerFooter>
+      </DrawerContent>
+    </Drawer>
   );
 };
 

--- a/src/pages/JoinComplete/JoinComplete.tsx
+++ b/src/pages/JoinComplete/JoinComplete.tsx
@@ -15,9 +15,7 @@ const JoinComplete = () => {
           style={{ width: 300, height: 300 }}
         />
       </Suspense>
-      <p className="font-bold text-3xl mt-4 mb-16">
-        등록이 완료됐어요
-      </p>
+      <p className="mt-4 mb-16 font-bold text-3xl">등록이 완료됐어요</p>
       <DiscordNotice />
       <KakaoChatroom />
     </Wrapper>
@@ -25,8 +23,11 @@ const JoinComplete = () => {
 };
 
 const Wrapper = ({ children }: { children: React.ReactNode }) => {
-  return <div className="mx-auto mb-8 w-full max-w-md px-4 py-8 pb-28 text-center space-y-4 mt-16">{children}</div>; 
+  return (
+    <div className="mx-auto mt-16 mb-8 w-full max-w-md space-y-4 px-4 py-8 pb-28 text-center">
+      {children}
+    </div>
+  );
 };
-
 
 export default JoinComplete;

--- a/src/pages/JoinComplete/JoinComplete.tsx
+++ b/src/pages/JoinComplete/JoinComplete.tsx
@@ -7,35 +7,26 @@ const Lottie = lazy(() => import("lottie-react"));
 
 const JoinComplete = () => {
   return (
-    <AlignCenter>
-      <Wrapper>
-        <Suspense fallback={<div style={{ width: 300, height: 300 }} />}>
-          <Lottie
-            animationData={Rocket}
-            loop={true}
-            style={{ width: 300, height: 300 }}
-          />
-        </Suspense>
-        <p className="text-muted-foreground text-xl">
-          성공적으로 가입이 완료되었습니다.
-        </p>
-        <DiscordNotice />
-        <KakaoChatroom />
-      </Wrapper>
-    </AlignCenter>
+    <Wrapper>
+      <Suspense fallback={<div style={{ width: 300, height: 300 }} />}>
+        <Lottie
+          animationData={Rocket}
+          loop={true}
+          style={{ width: 300, height: 300 }}
+        />
+      </Suspense>
+      <p className="font-bold text-3xl mt-4 mb-16">
+        등록이 완료됐어요
+      </p>
+      <DiscordNotice />
+      <KakaoChatroom />
+    </Wrapper>
   );
 };
 
 const Wrapper = ({ children }: { children: React.ReactNode }) => {
-  return <div className="space-y-4">{children}</div>;
+  return <div className="mx-auto mb-8 w-full max-w-md px-4 py-8 pb-28 text-center space-y-4 mt-16">{children}</div>; 
 };
 
-const AlignCenter = ({ children }: { children: React.ReactNode }) => {
-  return (
-    <div className="flex flex-1 items-center justify-center p-6 text-center">
-      {children}
-    </div>
-  );
-};
 
 export default JoinComplete;


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **신규 기능**
  * 카카오톡 채팅방 참여 UI가 데스크탑에서는 모달, 모바일에서는 드로어로 반응형 제공됩니다.
  * 비밀번호 복사 시 2초간 체크 아이콘으로 피드백이 제공됩니다.

* **개선 사항**
  * 가입 완료 및 디스코드 안내 문구가 더 간결하고 자연스럽게 변경되었습니다.
  * 가입 완료 화면의 레이아웃과 텍스트 스타일이 개선되어 가독성이 향상되었습니다.

* **리팩터**
  * 카카오톡 채팅방 관련 UI 컴포넌트가 더 모듈화되어 관리가 쉬워졌습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->