### PR TITLE
feat(JOIN-195): /auth/check 의 상태에따라 진행 상태 변경

### DIFF
--- a/src/stores/authStore.ts
+++ b/src/stores/authStore.ts
@@ -18,7 +18,7 @@ interface AuthState {
 }
 
 interface AuthResponse {
-  status: 'PENDING' | 'COMPLETED';
+  status: "PENDING" | "COMPLETED";
 }
 
 export const useAuthStore = create<AuthState>((set) => ({
@@ -35,7 +35,6 @@ export const useAuthStore = create<AuthState>((set) => ({
       if (data.status === "COMPLETED") {
         set({ isAuthenticated: AuthStatus.COMPLETED });
       }
-      
     } catch (error) {
       // 401 에러 또는 네트워크 에러 발생 시 인증 실패 상태로 변경
       const serverError = error as ServerError;


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- 버그 수정
  - 인증 상태 확인 시 서버의 진행(PENDING)/완료(COMPLETED) 값을 그대로 반영해 단계 표시와 접근 제어가 더 정확하고 일관되게 동작합니다.
  - 401 응답 시 즉시 미인증으로 전환하고, 기타 오류는 기록 후 안전하게 미인증으로 처리해 예외 상황에서도 예측 가능한 동작을 보장합니다.
  - 회원가입 완료 및 로그아웃 흐름에는 변화가 없어 기존 사용 경험을 유지합니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->