### PR TITLE
feat(JOIN-235): 로그인에 홈페이지 버튼 추가, 이메일을 밑으로

### DIFF
--- a/src/pages/LoginPage.tsx
+++ b/src/pages/LoginPage.tsx
@@ -1,9 +1,8 @@
+import { ExternalLinkIcon } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { useExternalBrowser } from "@/hooks/useExternalBrowser";
 import { Analytics } from "@/service/analytics";
 import BrowserRedirectPage from "./BrowserRedirectPage";
-import { Label } from "@/components/ui/label";
-import { ExternalLinkIcon } from "lucide-react";
 
 const LoginPage = () => {
   const { isKakaoInApp } = useExternalBrowser();
@@ -54,28 +53,32 @@ const LoginPage = () => {
           className="w-full"
           asChild
         >
-          <a href="https://dkuaegis.org/" target="_blank" rel="noopener noreferrer">
+          <a
+            href="https://dkuaegis.org/"
+            target="_blank"
+            rel="noopener noreferrer"
+          >
             Aegis 홈페이지
           </a>
         </Button>
       </div>
-    <div className="flex flex-col text-center">
-      <a
-        href="https://sites.google.com/dankook.ac.kr/help"
-        target="_blank"
-        rel="noopener noreferrer"
-        className="text-muted-foreground text-sm font-extrabold underline inline-flex items-center justify-center gap-1"
-        onClick={() => {
-          Analytics.safeTrack("Gmail_Guide_Click", {
-            category: "Link",
-            method: "Guide",
-          });
-        }}      
-      >
-        단국대 Gmail 생성 가이드
-        <ExternalLinkIcon className="h-4 w-4" /> 
-      </a>
-    </div>
+      <div className="flex flex-col text-center">
+        <a
+          href="https://sites.google.com/dankook.ac.kr/help"
+          target="_blank"
+          rel="noopener noreferrer"
+          className="inline-flex items-center justify-center gap-1 font-extrabold text-muted-foreground text-sm underline"
+          onClick={() => {
+            Analytics.safeTrack("Gmail_Guide_Click", {
+              category: "Link",
+              method: "Guide",
+            });
+          }}
+        >
+          단국대 Gmail 생성 가이드
+          <ExternalLinkIcon className="h-4 w-4" />
+        </a>
+      </div>
     </div>
   );
 };


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - 로그인 페이지에 Aegis 홈페이지로 이동하는 버튼을 추가하고 새 탭에서 열리도록 개선.
  - 버튼 하단에 ‘단국대 Gmail 생성 가이드’ 링크 블록을 추가하여 새 탭으로 열리고 외부 링크 아이콘을 표시.
- Style
  - 가이드 링크에 굵은체, 작은 크기, 밑줄 등 가독성 향상 스타일 적용.
  - 레이아웃에 가이드 전용 블록을 추가해 화면 구성이 더 명확해짐.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->