### PR TITLE
fix(FE-356): lottifile alias 제거

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -10,7 +10,6 @@ export default defineConfig({
   resolve: {
     alias: {
       "@": path.resolve(__dirname, "./src"),
-      "lottie-web": "lottie-web/build/player/lottie_light",
     },
   },
   build: {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **Chores**
  * 빌드 설정에서 특정 라이브러리 alias 항목을 제거하여 설정을 간소화했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->